### PR TITLE
Update the default config values

### DIFF
--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -24,7 +24,7 @@ public class SentrySdk : MonoBehaviour
     [Header("Send PII like User and Computer names")]
     public bool SendDefaultPii = false;
     [Header("Enable auto generate breadcrumb")]
-    public bool AutoGenerateBreadcrumb = false;
+    public bool AutoGenerateBreadcrumb = true;
     [Header("Enable SDK debug messages")]
     public bool Debug = true;
     [Header("Override game version")]

--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -26,7 +26,7 @@ public class SentrySdk : MonoBehaviour
     [Header("Enable auto generate breadcrumb")]
     public bool AutoGenerateBreadcrumb = true;
     [Header("Enable SDK debug messages")]
-    public bool Debug = true;
+    public bool Debug = false;
     [Header("Override game version")]
     public string Version = "";
 

--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -22,7 +22,7 @@ public class SentrySdk : MonoBehaviour
     [Header("DSN of your sentry instance")]
     public string Dsn;
     [Header("Send PII like User and Computer names")]
-    public bool SendDefaultPii = true;
+    public bool SendDefaultPii = false;
     [Header("Enable auto generate breadcrumb")]
     public bool AutoGenerateBreadcrumb = false;
     [Header("Enable SDK debug messages")]


### PR DESCRIPTION
This is a breaking (behavioral) change, but if we're changing the package name anyway, there's no need to keep using strange defaults.