### PR TITLE
cleanup: Remove UNITY_5 ifdefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ run headless. There are two important APIs that are worth considering.
 
 ### Unity version
 
-The lowest required version is Unity 5.6.
-Previous versions might work but were not tested and will not be supported.
-
+The lowest required version is Unity 2018.4. Previous versions might work, but
+were not tested and will not be supported.
 
 ### Native Crash Support
 

--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -1,7 +1,4 @@
 using System;
-#if UNITY_5
-using System.Collections;
-#endif
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;
@@ -347,11 +344,7 @@ public class SentrySdk : MonoBehaviour
         ModifySentryEvent?.Invoke(@event);
     }
 
-    private IEnumerator
-#if !UNITY_5
-        <UnityWebRequestAsyncOperation>
-#endif
-        ContinueSendingEvent<T>(T @event)
+    private IEnumerator<UnityWebRequestAsyncOperation> ContinueSendingEvent<T>(T @event)
         where T : SentryEvent
     {
         PrepareEvent(@event);
@@ -374,23 +367,13 @@ public class SentrySdk : MonoBehaviour
         www.SetRequestHeader("X-Sentry-Auth", authString);
         www.uploadHandler = new UploadHandlerRaw(Encoding.UTF8.GetBytes(jsonString));
         www.downloadHandler = new DownloadHandlerBuffer();
-#if UNITY_5
-        yield return www.Send();
-#else
         yield return www.SendWebRequest();
-#endif
 
         while (!www.isDone)
         {
             yield return null;
         }
-        if (
-#if UNITY_5
-            www.isError
-#else
-            www.isNetworkError || www.isHttpError
-#endif
-             || www.responseCode != 200)
+        if (www.isNetworkError || www.isHttpError || www.responseCode != 200)
         {
             UnityDebug.LogWarning("error sending request to sentry: " + www.error);
         }


### PR DESCRIPTION
Unity 5 doesn't support UPM anyway, so no point in keeping the old
ifdefs.