### PR TITLE
Don't send sentry errors in editor mode

### DIFF
--- a/Runtime/SentrySdk.cs
+++ b/Runtime/SentrySdk.cs
@@ -27,6 +27,9 @@ public class SentrySdk : MonoBehaviour
     [Header("Override game version")]
     public string Version = "";
 
+    [Header("Misc")]
+    [SerializeField] bool _enableInEditor;
+
     private string _lastErrorMessage = "";
     private Dsn _dsn;
     private bool _initialized = false;
@@ -37,6 +40,14 @@ public class SentrySdk : MonoBehaviour
 
     public void Start()
     {
+#if UNITY_EDITOR
+        if (!_enableInEditor)
+        {
+            UnityDebug.Log("Sentry: Not reporting errors in editor");
+            Destroy(this);
+        }
+#endif
+
         if (Dsn == string.Empty)
         {
             // Empty string = disabled SDK


### PR DESCRIPTION
This just deletes the sentry component. This is the simplest solution.

This destroys the component as opposed to destroying the gameobject, which is more dangerous, as the sentry object might be on a gameobject with other components.

This is kind of a breaking change, since it changes behavior. We could have defaulted to report errors in the editor as well, but that's just silly.

Behavior is not changed in builds, though, so should be ok.